### PR TITLE
Ensure that phpunit only runs when php files have changed

### DIFF
--- a/config-dist/build-pre-commit.xml.dist
+++ b/config-dist/build-pre-commit.xml.dist
@@ -199,7 +199,7 @@
         PHPUnit always runs, regardless of there being changes in PHP src.
         This is because other changes, e.g. config, can also break tests
     -->
-    <target name="phpunit" depends="set-test-tree-location">
+    <target name="phpunit" depends="set-test-tree-location" if="changeset.php.notempty">
         <exec outputproperty="phpunit-output-raw" resultproperty="phpunit-exitcode"
               executable="${test-tree-location}/{{ composerBinDir }}/phpunit" failonerror="false">
             <arg line="--configuration=${test-tree-location}/{{ phpUnitConfigPath }} --stop-on-failure"/>

--- a/src/Ibuildings/QA/tests/Common/Console/fixtures/build-pre-commit.xml
+++ b/src/Ibuildings/QA/tests/Common/Console/fixtures/build-pre-commit.xml
@@ -181,7 +181,7 @@
         PHPUnit always runs, regardless of there being changes in PHP src.
         This is because other changes, e.g. config, can also break tests
     -->
-    <target name="phpunit" depends="set-test-tree-location">
+    <target name="phpunit" depends="set-test-tree-location" if="changeset.php.notempty">
         <exec outputproperty="phpunit-output-raw" resultproperty="phpunit-exitcode"
               executable="${test-tree-location}/vendor/bin/phpunit" failonerror="false">
             <arg line="--configuration=${test-tree-location}/ --stop-on-failure"/>


### PR DESCRIPTION
this change is only effective in the pre-commit hook.

Resolves #4 
