### PR TITLE
added quotes to phpunit command

### DIFF
--- a/config-dist/build-pre-commit.xml.dist
+++ b/config-dist/build-pre-commit.xml.dist
@@ -202,7 +202,7 @@
     <target name="phpunit" depends="set-test-tree-location">
         <exec outputproperty="phpunit-output-raw" resultproperty="phpunit-exitcode"
               executable="${test-tree-location}/{{ composerBinDir }}/phpunit" failonerror="false">
-            <arg line="--configuration=${test-tree-location}/{{ phpUnitConfigPath }} --stop-on-failure"/>
+            <arg line="--configuration='${test-tree-location}/{{ phpUnitConfigPath }}' --stop-on-failure"/>
         </exec>
         <condition property="phpunit-output" value="${phpunit-output-raw}" else="OK">
             <isfailure code="${phpunit-exitcode}"/>


### PR DESCRIPTION
When your project is located in a path that contains spaces, this causes errors with PHPUnit. Adding quotes around the path solves this issue. See also: https://github.com/ibuildingsnl/qa-tools/issues/23
