### PR TITLE
Bugfix/phpmd fixate pdepend to 1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": ">=5.3.3",
         "squizlabs/php_codesniffer": "~1.4",
-		"pdepend/pdepend":"1.1.*",
+        "pdepend/pdepend":"1.1.*",
         "phpmd/phpmd": "~1.5",
         "symfony/console": "~2.1",
         "symfony/filesystem": "~2.1",


### PR DESCRIPTION
Phpmd uses pdepend. The version in phpmd 1.5 's composer.json for pdepend is set to : ">=1.1.1" 

The pdepend 2.0.0 version does not appear to work with phpmd 1.5. 

It starts throwing out warnings like these when I try to run the pre-commit hook : 
PHP Warning:  require_once(PHP/Depend/Autoload.php): failed to open stream: No such file or directory in vendor/phpmd/phpmd/src/main/php/PHP/PMD/ParserFactory.php on line 48

This causes the commit to be aborted.

To fix this I've added the 1.1.\* version for pdepend in the company project (MD) and my own project. 

It would be very nice if this were fixed in the Ibuildings qa-tools. Hence the pull request .
