### PR TITLE
Explicitly require Mink Goutte driver >=1.0.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "behat/behat": "~2.5",
         "behat/mink": "*",
         "behat/mink-extension": "*",
-        "behat/mink-goutte-driver": "*",
+        "behat/mink-goutte-driver": ">=1.0.9",
         "behat/mink-selenium2-driver": "*",
         "camspiers/json-pretty": "~1.0"
     },


### PR DESCRIPTION
This PR somehow fixes #63, summarised below. It is unclear whether this is a Composer bug or intended behaviour.

---

As it stands, the QA tools don't install with a default Symfony2 SE installation on PHP 5.5.9.

To reproduce:

``` sh-session
$ composer create-project symfony/framework-standard-edition sf2qa \~2 -n
$ cd sf2qa
$ composer require --dev ibuildings/qa-tools:1.1.26
```
