### PR TITLE
[WIP] {milestone 3.1} NPM install task and executor

### DIFF
--- a/src/Core/Cli/Cli.php
+++ b/src/Core/Cli/Cli.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Ibuildings\QaTools\Core\Cli;
+
+use Symfony\Component\Process\ProcessBuilder;
+use Webmozart\Assert\Assert;
+
+class Cli
+{
+    /** @var array */
+    private static $installedExecutables = [];
+
+    /**
+     * Check whether an executable is installed on the local system
+     * Assumes a linux system with the `which` binary installed.
+     *
+     * @param string $executable
+     * @return bool
+     * @throws \Symfony\Component\Process\Exception\LogicException
+     */
+    public static function isExecutableInstalled($executable)
+    {
+        Assert::string($executable, 'Executable must be a string');
+
+        if (!array_key_exists($executable, self::$installedExecutables)) {
+            $process = ProcessBuilder::create(['which', $executable])->getProcess();
+            self::$installedExecutables[$executable] = $process->run() === 0;
+        }
+
+        return self::$installedExecutables[$executable];
+    }
+}

--- a/src/Core/Npm/CliNpmProject.php
+++ b/src/Core/Npm/CliNpmProject.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Ibuildings\QaTools\Core\Npm;
+
+use Ibuildings\QaTools\Core\Cli\Cli;
+use Ibuildings\QaTools\Core\Composer\RuntimeException;
+use Ibuildings\QaTools\Core\Project\Directory;
+use Symfony\Component\Process\ProcessBuilder;
+
+class CliNpmProject implements NpmProject
+{
+    /** @var Directory */
+    private $directory;
+    /** @var string */
+    private $npmExecutable;
+
+    /**
+     * CliNpmProject constructor.
+     * @param Directory       $directory
+     * @param string          $npmExecutable
+     */
+    public function __construct(Directory $directory, $npmExecutable)
+    {
+        $this->directory = $directory;
+        $this->npmExecutable = $npmExecutable;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isInitialised()
+    {
+        return file_exists($this->directory->getDirectory().'/package.json');
+    }
+
+    /**
+     * Initialise package.json
+     * @throws \Symfony\Component\Process\Exception\LogicException
+     * @throws \Ibuildings\QaTools\Core\Composer\RuntimeException
+     * @throws \Symfony\Component\Process\Exception\RuntimeException
+     */
+    public function initialise()
+    {
+        if (!Cli::isExecutableInstalled($this->npmExecutable)) {
+            throw new RuntimeException('Unable to initialise NPM because NPM is not installed', '');
+        }
+
+        $process = ProcessBuilder::create([$this->npmExecutable, 'init', '--yes'])->getProcess();
+        if ($process->run() !== 0) {
+            throw new RuntimeException('Unable to initialise NPM. Is NPM installed?', $process->getOutput());
+        }
+    }
+
+    /**
+     * Verify if a given set of NPM packages can be installed
+     *
+     * @param array $packages
+     * @return bool
+     * @throws \Symfony\Component\Process\Exception\RuntimeException
+     * @throws \Symfony\Component\Process\Exception\LogicException
+     */
+    public function verifyDevDependenciesCanBeInstalled(array $packages)
+    {
+        if (!Cli::isExecutableInstalled($this->npmExecutable)) {
+            return false;
+        }
+
+        $process = ProcessBuilder::create(array_merge([$this->npmExecutable, 'install', '--dry-run'], $packages))
+            ->setWorkingDirectory($this->directory->getDirectory())
+            ->getProcess();
+
+        return $process->run() === 0;
+    }
+
+    /**
+     * Install a given set of NPM packages
+     *
+     * @param array $packages
+     * @throws \Symfony\Component\Process\Exception\LogicException
+     * @throws \Symfony\Component\Process\Exception\RuntimeException
+     */
+    public function installDevDependencies(array $packages)
+    {
+        $process = ProcessBuilder::create(array_merge([$this->npmExecutable, 'install'], $packages))
+            ->setWorkingDirectory($this->directory->getDirectory())
+            ->getProcess();
+
+        $process->run();
+    }
+}

--- a/src/Core/Npm/CliNpmProjectFactory.php
+++ b/src/Core/Npm/CliNpmProjectFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Ibuildings\QaTools\Core\Npm;
+
+use Ibuildings\QaTools\Core\Assert\Assertion;
+use Ibuildings\QaTools\Core\Project\Directory;
+
+class CliNpmProjectFactory implements NpmProjectFactory
+{
+    /**
+     * @param string $directory
+     * @return CliNpmProject
+     * @throws \Assert\AssertionFailedException
+     */
+    public function forDirectory($directory)
+    {
+        Assertion::string($directory, 'NPM project directory ought to be a string, got "%s" of type "%s"');
+
+        return new CliNpmProject(new Directory($directory), 'npm');
+    }
+}

--- a/src/Core/Npm/NpmProject.php
+++ b/src/Core/Npm/NpmProject.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Ibuildings\QaTools\Core\Npm;
+
+interface NpmProject
+{
+    /**
+     * @return bool
+     */
+    public function isInitialised();
+
+    public function initialise();
+
+    /**
+     * @param array $packages
+     * @return bool
+     */
+    public function verifyDevDependenciesCanBeInstalled(array $packages);
+
+    /**
+     * @param array $packages
+     */
+    public function installDevDependencies(array $packages);
+}

--- a/src/Core/Npm/NpmProjectFactory.php
+++ b/src/Core/Npm/NpmProjectFactory.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Ibuildings\QaTools\Core\Npm;
+
+interface NpmProjectFactory
+{
+    /**
+     * @param string $directory
+     * @return NpmProject
+     */
+    public function forDirectory($directory);
+}

--- a/src/Core/Npm/RuntimeException.php
+++ b/src/Core/Npm/RuntimeException.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Ibuildings\QaTools\Core\Npm;
+
+use Exception;
+
+final class RuntimeException extends \RuntimeException
+{
+    /** @var string */
+    private $cause;
+
+    /**
+     * @param string         $message
+     * @param string         $cause A detailed, ideally human-readable, explanation of the cause of this exception.
+     * @param Exception|null $previous
+     */
+    public function __construct($message, $cause, Exception $previous = null)
+    {
+        parent::__construct($message, 0, $previous);
+
+        $this->cause = $cause;
+    }
+
+    /**
+     * Returns a detailed, ideally human-readable, explanation of the cause of this exception.
+     *
+     * @return string
+     */
+    public function getCause()
+    {
+        return $this->cause;
+    }
+}

--- a/src/Core/Task/Executor/InstallNpmDevDependencyTaskExecutor.php
+++ b/src/Core/Task/Executor/InstallNpmDevDependencyTaskExecutor.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Ibuildings\QaTools\Core\Task\Executor;
+
+use Ibuildings\QaTools\Core\Interviewer\Answer\YesOrNoAnswer;
+use Ibuildings\QaTools\Core\Interviewer\Interviewer;
+use Ibuildings\QaTools\Core\Interviewer\Question\QuestionFactory;
+use Ibuildings\QaTools\Core\Npm\CliNpmProject;
+use Ibuildings\QaTools\Core\Npm\CliNpmProjectFactory;
+use Ibuildings\QaTools\Core\Npm\RuntimeException;
+use Ibuildings\QaTools\Core\Project\Project;
+use Ibuildings\QaTools\Core\Task\InstallNpmDevDependencyTask;
+use Ibuildings\QaTools\Core\Task\Task;
+use Ibuildings\QaTools\Core\Task\TaskList;
+
+final class InstallNpmDevDependencyTaskExecutor implements Executor
+{
+    /** @var CliNpmProjectFactory $npmProjectFactory */
+    private $npmProjectFactory;
+    /** @var CliNpmProject $npmProject */
+    private $npmProject;
+
+    public function __construct(CliNpmProjectFactory $npmProjectFactory)
+    {
+        $this->npmProjectFactory = $npmProjectFactory;
+    }
+
+    public function supports(Task $task)
+    {
+        return $task instanceof InstallNpmDevDependencyTask;
+    }
+
+    public function arePrerequisitesMet(TaskList $tasks, Project $project, Interviewer $interviewer)
+    {
+        $interviewer->notice(
+            " * Verifying installation of NPM development dependencies won't cause a conflict..."
+        );
+
+        $this->npmProject = $this->npmProjectFactory->forDirectory($project->getRootDirectory()->getDirectory());
+
+        if (!$this->npmProject->isInitialised()) {
+            /** @var YesOrNoAnswer $answer */
+            $answer = $interviewer->ask(
+                QuestionFactory::createYesOrNo(
+                    'There is no NPM project initialised in this directory. Initialise one?',
+                    YesOrNoAnswer::YES
+                )
+            );
+
+            if ($answer->is(YesOrNoAnswer::NO)) {
+                $interviewer->warn('Cannot continue without an initialised NPM project. Aborting...');
+
+                return false;
+            }
+
+            try {
+                $this->npmProject->initialise();
+            } catch (RuntimeException $e) {
+                $interviewer->warn('Something went wrong while initialising the NPM project:');
+                $interviewer->warn($e->getCause());
+
+                return false;
+            }
+
+            $interviewer->notice(
+                "Verifying installation of NPM development dependencies won't cause a conflict..."
+            );
+        }
+
+        $packages = $this->getPackagesFromTasks($tasks);
+
+        return $this->npmProject->verifyDevDependenciesCanBeInstalled($packages);
+    }
+
+    public function execute(TaskList $tasks, Project $project, Interviewer $interviewer)
+    {
+        $this->npmProject->installDevDependencies($this->getPackagesFromTasks($tasks));
+    }
+
+    public function cleanUp(TaskList $tasks, Project $project, Interviewer $interviewer)
+    {
+    }
+
+    public function rollBack(TaskList $tasks, Project $project, Interviewer $interviewer)
+    {
+    }
+
+    private function getPackagesFromTasks($tasks)
+    {
+        $packages = [];
+        /** @var InstallNpmDevDependencyTask $task */
+        foreach ($tasks as $task) {
+            $packages[] = $task->getPackageName().'@'.$task->getPackageVersionConstraint();
+        }
+        return $packages;
+    }
+}

--- a/src/Core/Task/InstallNpmDevDependencyTask.php
+++ b/src/Core/Task/InstallNpmDevDependencyTask.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Ibuildings\QaTools\Core\Task;
+
+use Ibuildings\QaTools\Core\Assert\Assertion;
+
+final class InstallNpmDevDependencyTask implements Task
+{
+    /** @var string */
+    private $packageName;
+    /** @var string */
+    private $packageVersionConstraint;
+
+    /**
+     * @param string $packageName
+     * @param string $packageVersionConstraint
+     */
+    public function __construct($packageName, $packageVersionConstraint)
+    {
+        Assertion::string($packageName, 'NPM package name ought to be a string, got "%s" of type "%s"');
+        Assertion::string(
+            $packageVersionConstraint,
+            'NPM package version constraint ought to be a string, got "%s" of type "%s"'
+        );
+
+        $this->packageName = $packageName;
+        $this->packageVersionConstraint = $packageVersionConstraint;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPackageName()
+    {
+        return $this->packageName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPackageVersionConstraint()
+    {
+        return $this->packageVersionConstraint;
+    }
+
+    public function __toString()
+    {
+        return sprintf(
+            'InstallNpmDevDependencyTask("%s:%s")',
+            $this->packageName,
+            $this->packageVersionConstraint
+        );
+    }
+}

--- a/tests/integration/Core/Cli/Cli.php
+++ b/tests/integration/Core/Cli/Cli.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Ibuildings\QaTools\IntegrationTest\Core\Cli;
+
+use Ibuildings\QaTools\Core\Cli\Cli;
+use PHPUnit\Framework\TestCase;
+
+final class CliTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function detects_installed_executable()
+    {
+        $this->assertTrue(
+            Cli::isExecutableInstalled('ls'),
+            'Cli should have been able to detect that "ls" is installed on your system. Are you running windows?'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function detects_executable_not_installed()
+    {
+        $this->assertFalse(
+            Cli::isExecutableInstalled('abcdefgzyxopjn'),
+            'Cli was able to find a binary called "abcdefgzyxopjn", but expected not to.'
+        );
+    }
+}

--- a/tests/integration/Core/Npm/CliNpmProjectTest.php
+++ b/tests/integration/Core/Npm/CliNpmProjectTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace integration\Core\Npm;
+
+use Ibuildings\QaTools\Core\Cli\Cli;
+use Ibuildings\QaTools\Core\Npm\CliNpmProject;
+use Ibuildings\QaTools\Core\Project\Directory;
+use Mockery;
+use Mockery\Mock;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+final class CliNpmProjectTest extends TestCase
+{
+    /** @var LoggerInterface|Mock */
+    private $logger;
+    /** @var CliNpmProject */
+    private $project;
+
+    public function setUp()
+    {
+        $tempDirectory = sys_get_temp_dir().'/qa-npm';
+        $filesystem = new Filesystem();
+        if ($filesystem->exists($tempDirectory)) {
+            $filesystem->remove($tempDirectory);
+        }
+        $filesystem->mkdir($tempDirectory);
+
+        $this->logger = Mockery::mock(LoggerInterface::class);
+        $this->project = new CliNpmProject(new Directory($tempDirectory), 'npm', $this->logger);
+    }
+
+    /**
+     * @test
+     */
+    public function fails_on_dependency_installation_problem()
+    {
+        if (!Cli::isExecutableInstalled('npm')) {
+            $this->markTestSkipped('Unable to run integration test against NPM because NPM is not installed');
+        }
+
+        $this->assertEquals(
+            false,
+            $this->project->verifyDevDependenciesCanBeInstalled(['some-non-existing-package@99.99.99'])
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function succeeds_when_packages_could_be_installed()
+    {
+        if (!Cli::isExecutableInstalled('npm')) {
+            $this->markTestSkipped('Unable to run integration test against NPM because NPM is not installed');
+        }
+
+        $this->assertEquals(
+            true,
+            $this->project->verifyDevDependenciesCanBeInstalled(['eslint@3.10.0'])
+        );
+    }
+}

--- a/tests/unit/Core/Task/Executor/InstallNpmDevDependencyTaskExecutorTest.php
+++ b/tests/unit/Core/Task/Executor/InstallNpmDevDependencyTaskExecutorTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Ibuildings\QaTools\UnitTest\Core\Task\Executor;
+
+use Ibuildings\QaTools\Core\Interviewer\Answer\YesOrNoAnswer;
+use Ibuildings\QaTools\Core\Interviewer\AutomatedResponseInterviewer;
+use Ibuildings\QaTools\Core\Interviewer\Interviewer;
+use Ibuildings\QaTools\Core\Npm\CliNpmProject;
+use Ibuildings\QaTools\Core\Npm\CliNpmProjectFactory;
+use Ibuildings\QaTools\Core\Project\Project;
+use Ibuildings\QaTools\Core\Task\Executor\InstallNpmDevDependencyTaskExecutor;
+use Ibuildings\QaTools\Core\Task\InstallNpmDevDependencyTask;
+use Ibuildings\QaTools\Core\Task\Task;
+use Ibuildings\QaTools\Core\Task\TaskList;
+use Mockery;
+use Mockery\Mock;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group Task
+ * @group TaskExecutor
+ */
+class InstallNpmDevDependencyTaskExecutorTest extends TestCase
+{
+    /** @var Project|Mock */
+    private $project;
+    /** @var Interviewer|Mock */
+    private $interviewer;
+    /** @var InstallNpmDevDependencyTaskExecutor */
+    private $executor;
+    /** @var CliNpmProject|Mock */
+    private $npmProject;
+    /** @var CliNpmProjectFactory|Mock */
+    private $npmProjectFactory;
+
+    protected function setUp()
+    {
+        $this->npmProject = Mockery::spy(CliNpmProject::class);
+        $this->npmProjectFactory = Mockery::mock(CliNpmProjectFactory::class);
+        $this->npmProjectFactory->shouldReceive('forDirectory')->with('./')->andReturn($this->npmProject);
+
+        $this->project = Mockery::mock(Project::class);
+        $this->interviewer = Mockery::mock(Interviewer::class);
+        $this->interviewer->shouldReceive('notice');
+
+        $this->executor = new InstallNpmDevDependencyTaskExecutor($this->npmProjectFactory);
+    }
+
+    /**
+     * @test
+     */
+    public function supports_install_npm_dev_dependency_tasks()
+    {
+        $task = new InstallNpmDevDependencyTask('foobar', '1.0');
+        $this->assertTrue(
+            $this->executor->supports($task),
+            'InstallNpmDevDependencyTaskExecutor should be able to handle InstallNpmDevDependencyTask instance'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function does_not_support_any_other_kind_of_task()
+    {
+        /** @var Task|Mock $task */
+        $task = Mockery::mock(Task::class);
+        $this->assertFalse(
+            $this->executor->supports($task),
+            'InstallNpmDevDependencyTaskExecutor should only support InstallNpmDevDependencyTask instances'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function prerequisites_are_met_when_package_could_be_installed()
+    {
+        $this->npmProject->shouldReceive('isInitialised')->andReturn(true);
+        $this->project->shouldReceive('getRootDirectory->getDirectory')->andReturn('./');
+
+        $this->npmProject
+            ->shouldReceive('verifyDevDependenciesCanBeInstalled')
+            ->with(['eslint@3.10.0'])
+            ->andReturn(true);
+
+        $taskList = new TaskList([new InstallNpmDevDependencyTask('eslint', '3.10.0')]);
+        $this->assertTrue($this->executor->arePrerequisitesMet($taskList, $this->project, $this->interviewer));
+    }
+
+    /**
+     * @test
+     */
+    public function prerequisites_are_not_met_when_package_could_not_be_installed()
+    {
+        $this->npmProject->shouldReceive('isInitialised')->andReturn(true);
+        $this->project->shouldReceive('getRootDirectory->getDirectory')->andReturn('./');
+
+        $this->npmProject
+            ->shouldReceive('verifyDevDependenciesCanBeInstalled')
+            ->with(['brokenpackage@1.0.0'])
+            ->andReturn(false);
+
+        $taskList = new TaskList([new InstallNpmDevDependencyTask('brokenpackage', '1.0.0')]);
+        $this->assertFalse($this->executor->arePrerequisitesMet($taskList, $this->project, $this->interviewer));
+    }
+
+    /**
+     * @test
+     */
+    public function npm_project_is_initialised_if_not_initialised_and_user_wants_this()
+    {
+        $this->npmProject->shouldReceive('isInitialised')->andReturn(false);
+
+        $this->project->shouldReceive('getRootDirectory->getDirectory')->andReturn('./');
+        $taskList = new TaskList([new InstallNpmDevDependencyTask('eslint', '3.10.0')]);
+
+        $interviewer = new AutomatedResponseInterviewer();
+        $interviewer->recordAnswer('Initialise one?', YesOrNoAnswer::yes());
+
+        $this->npmProject->shouldReceive('verifyDevDependenciesCanBeInstalled')->andReturn(true);
+
+        $this->executor->arePrerequisitesMet($taskList, $this->project, $interviewer);
+
+        $this->npmProject->shouldHaveReceived('initialise');
+    }
+
+    /**
+     * @test
+     */
+    public function npm_project_is_not_initialised_if_user_does_not_want_this()
+    {
+        $this->npmProject->shouldReceive('isInitialised')->andReturn(false);
+
+        $this->project->shouldReceive('getRootDirectory->getDirectory')->andReturn('./');
+        $taskList = new TaskList([new InstallNpmDevDependencyTask('eslint', '3.10.0')]);
+
+        $interviewer = new AutomatedResponseInterviewer();
+        $interviewer->recordAnswer('Initialise one?', YesOrNoAnswer::no());
+
+        $this->executor->arePrerequisitesMet($taskList, $this->project, $interviewer);
+
+        $this->npmProject->shouldNotHaveReceived('initialise');
+    }
+}


### PR DESCRIPTION
As [originally](https://github.com/ibuildingsnl/qa-tools-v3/pull/87) submitted by @rpkamp:

---

Initial setup of NPM install task and TaskExecutor. Needs some more attention, but I'm just putting it out there for early feedback.

TODO:

- [ ] Value objects for NPM packages, package names, package versions, package sets
- [ ] Rollback when install failed
- [ ] Make tests independent of an internet connection. Thus far I have been unable to convince `npm` to work when there is no internet connection. The idea @DRvanR had is to make the package version optional, so we can use paths to `node_modules` directories as "package name". `npm` should be able to install paths without requiring an internet connection from what I've read :crossed_fingers: 