### PR TITLE
Allow contributor to attach stability label to released version

### DIFF
--- a/.rmt.yml
+++ b/.rmt.yml
@@ -17,7 +17,9 @@ _default:
     #  Apply to all branches except the one from the 'branch-specific' section
     #  Like prerequisites, you can add your own script. Example:
     #   - relative/path/to/your-own-sript.php
-    version-generator: semantic # More complex versionning (semantic)
+    version-generator:
+        semantic:
+            allow-label: true
     version-persister:
         vcs-tag:                           # Release with VCS tag
             tag-prefix: "{branch-name}_"   # Prefix any tag with the VCS branch name

--- a/composer.lock
+++ b/composer.lock
@@ -1636,16 +1636,16 @@
         },
         {
             "name": "liip/rmt",
-            "version": "1.2.5",
+            "version": "1.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liip/RMT.git",
-                "reference": "db89cfab05e89257f08bfc91f3ca2989ab88fcb7"
+                "reference": "41c32996aaaf95c508927d77bbca67e2795dbc78"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liip/RMT/zipball/db89cfab05e89257f08bfc91f3ca2989ab88fcb7",
-                "reference": "db89cfab05e89257f08bfc91f3ca2989ab88fcb7",
+                "url": "https://api.github.com/repos/liip/RMT/zipball/41c32996aaaf95c508927d77bbca67e2795dbc78",
+                "reference": "41c32996aaaf95c508927d77bbca67e2795dbc78",
                 "shasum": ""
             },
             "require": {
@@ -1691,7 +1691,7 @@
                 "vcs tag",
                 "version"
             ],
-            "time": "2016-09-09 13:48:33"
+            "time": "2016-11-07 05:33:08"
         },
         {
             "name": "mnapoli/front-yaml",


### PR DESCRIPTION
I want to start releasing alpha versions soon so the installer, self-updating etc. can be tested before releasing an internal beta on March 1st. This change asks the contributor whether a stability label should be attached to the version-to-be-released.

![image](https://cloud.githubusercontent.com/assets/1734555/23066586/9a1544c2-f51b-11e6-8659-a3824ec2a53e.png)
