### PR TITLE
Make self-update rollback option a flag

### DIFF
--- a/src/Core/Application/Command/SelfUpdateCommand.php
+++ b/src/Core/Application/Command/SelfUpdateCommand.php
@@ -28,7 +28,7 @@ final class SelfUpdateCommand extends Command implements ContainerAwareInterface
             ->setAliases(['selfupdate'])
             ->setDescription('Updates Ibuildings QA Tools to the latest version')
             ->setHelp('Updates Ibuildings QA Tools to the latest version')
-            ->addOption('rollback', null, InputOption::VALUE_NONE | InputOption::VALUE_OPTIONAL);
+            ->addOption('rollback', null, InputOption::VALUE_NONE);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)


### PR DESCRIPTION
The command's rollback option accepted a value, which wasn't not very clear to the user. Only when the user specified a truthy value is the rollback performed. This commit changes it to a flag. Its resulting boolean value is used to decide whether to upgrade or to roll back.

Fixes #105 