### PR TITLE
State possible causes for system test failure in failure message

### DIFF
--- a/src/Core/Composer/CliComposerProject.php
+++ b/src/Core/Composer/CliComposerProject.php
@@ -184,6 +184,7 @@ final class CliComposerProject implements Project
     {
         return file_put_contents('composer.json', $json);
     }
+
     /**
      * Writes the given string to the Composer lock file in the current working directory.
      *

--- a/src/Core/Composer/CliComposerProject.php
+++ b/src/Core/Composer/CliComposerProject.php
@@ -125,14 +125,9 @@ final class CliComposerProject implements Project
         if ($process->run() !== 0) {
             $packageNames = join("\n - ", $packages->getDescriptors());
 
-            $this->logger->error(
-                "Failed to require development dependencies\n" .
-                "One of these packages could not be installed (from inside $this->directory):\n" .
-                " - $packageNames\n" .
-                "Maybe you forgot to:\n" .
-                " - add a composer.json fixture for the package to 'tests/composer/packages'\n" .
-                " - add the package to '\\Ibuildings\\QaTools\\SystemTest\\Composer::initialise'"
-            );
+            $this->logger->error("Failed to require development dependencies");
+            $this->logger->error("One of these packages could not be installed (from inside $this->directory):");
+            $this->logger->error(" - $packageNames");
 
             throw new RuntimeException(
                 'Failed to require development dependencies',

--- a/tests/system/SystemTest.php
+++ b/tests/system/SystemTest.php
@@ -76,9 +76,36 @@ final class SystemTest extends TestCase
 
         $expectStdout = preg_replace('~^~', '  ', $process->getOutput());
         $expectStderr = preg_replace('~^~', '  ', $process->getErrorOutput());
+
+        $message = <<<MESSAGE
+▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
+
+QA Tools distributable terminated with non-zero exit code %d.
+
+Possible causes:
+  1. QA Tools did not output the expected text within a certain amount of time. Check the output of QA Tools below.
+  2. A Composer package could not be installed.
+     Maybe you forgot to:
+       - Add a composer.json fixture for the package to 'tests/composer/packages'
+       - Add the package to '\\Ibuildings\\QaTools\\SystemTest\\Composer::initialise'
+     Composer packages are mocked. Please read the documentation on why, and how to mock yours: docs/development/writing-system-tests.md.
+
+CWD:
+%s
+
+STDOUT:
+%s
+
+STDERR:
+%s
+
+▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
+
+MESSAGE;
+
         $this->fail(
             sprintf(
-                "QA Tools distributable terminated with non-zero exit code %d.\n\nCWD:\n  %s\nSTDOUT:\n%s\nSTDERR:\n%s",
+                $message,
                 $process->getExitCode(),
                 getcwd(),
                 $expectStdout,


### PR DESCRIPTION
Fixes #112 by moving possible test environment causes for not being able to install a Composer package to the system test failure message.