### PR TITLE
Perform full Composer dev dependency conflict detection

### DIFF
--- a/src/Core/Composer/CliComposerProject.php
+++ b/src/Core/Composer/CliComposerProject.php
@@ -138,12 +138,12 @@ final class CliComposerProject implements Project
 
     public function restoreConfiguration(Configuration $configuration)
     {
-        $this->writeComposerJson($configuration->getComposerJson());
+        file_put_contents('composer.json', $configuration->getComposerJson());
 
         if ($configuration->hasLockedDependencies()) {
-            $this->writeComposerLockJson($configuration->getComposerLockJson());
+            file_put_contents('composer.lock', $configuration->getComposerLockJson());
         } elseif (file_exists('composer.lock')) {
-            $this->removeComposerLock();
+            unlink('composer.lock');
         }
 
         $options = ['--no-interaction'];
@@ -160,32 +160,5 @@ final class CliComposerProject implements Project
                 $process->getErrorOutput()
             );
         }
-    }
-
-    /**
-     * Writes the given string to the Composer file in the current working directory.
-     *
-     * @param string $json
-     * @return string
-     */
-    private function writeComposerJson($json)
-    {
-        return file_put_contents('composer.json', $json);
-    }
-
-    /**
-     * Writes the given string to the Composer lock file in the current working directory.
-     *
-     * @param string $json
-     * @return string
-     */
-    private function writeComposerLockJson($json)
-    {
-        return file_put_contents('composer.lock', $json);
-    }
-
-    private function removeComposerLock()
-    {
-        unlink('composer.lock');
     }
 }

--- a/src/Core/Composer/CliComposerProject.php
+++ b/src/Core/Composer/CliComposerProject.php
@@ -73,43 +73,11 @@ final class CliComposerProject implements Project
     {
         $this->backUpConfiguration();
 
-        $options = ['--dev', '--no-update', '--no-interaction'];
-        $arguments = array_merge([$this->composerBinary, 'require'], $options, $packages->getDescriptors());
-        $process = ProcessBuilder::create($arguments)
-            ->setWorkingDirectory($this->directory)
-            ->setEnv('COMPOSER_HOME', getenv('COMPOSER_HOME'))
-            ->setTimeout(null)
-            ->getProcess();
-
-        if ($process->run() !== 0) {
-            // Restore the old JSON in case Composer wrote to the Composer file anyway.
+        try {
+            $this->requireDevDependencies($packages);
+        } finally {
             $this->restoreConfiguration();
-
-            throw new RuntimeException(
-                'Failed to add development packages to Composer file',
-                $process->getErrorOutput()
-            );
         }
-
-        $options = ['--dry-run', '--no-interaction'];
-        $arguments = array_merge([$this->composerBinary, 'install'], $options);
-        $process = ProcessBuilder::create($arguments)
-            ->setWorkingDirectory($this->directory)
-            ->setEnv('COMPOSER_HOME', getenv('COMPOSER_HOME'))
-            ->setTimeout(null)
-            ->getProcess();
-
-        if ($process->run() !== 0) {
-            $this->restoreConfiguration();
-
-            throw new RuntimeException(
-                'Failed to dry-run Composer packages installation',
-                $process->getErrorOutput()
-            );
-        }
-
-        // Restore the old JSON to remove the added development dependencies.
-        $this->restoreConfiguration();
     }
 
     public function requireDevDependencies(PackageSet $packages)

--- a/src/Core/Composer/CliComposerProject.php
+++ b/src/Core/Composer/CliComposerProject.php
@@ -122,11 +122,6 @@ final class CliComposerProject implements Project
         }
     }
 
-    /**
-     * Returns the Composer configuration currently on disk.
-     *
-     * @return Configuration
-     */
     public function readConfiguration()
     {
         if (file_exists('composer.lock')) {

--- a/src/Core/Composer/Project.php
+++ b/src/Core/Composer/Project.php
@@ -34,19 +34,18 @@ interface Project
     public function requireDevDependencies(PackageSet $packages);
 
     /**
-     * Backs up the current Composer configuration for later restoration.
+     * Returns the current Composer configuration for later restoration.
      *
-     * @return void
+     * @return Configuration
      * @throws RuntimeException
      */
-    public function backUpConfiguration();
+    public function readConfiguration();
 
     /**
-     * Restores the backed up Composer configuration and installs the locked
-     * dependencies. The backup is not cleared after restoration.
+     * Restores the given Composer configuration and installs the locked dependencies.
      *
+     * @param Configuration $configuration
      * @return void
-     * @throws RuntimeException
      */
-    public function restoreConfiguration();
+    public function restoreConfiguration(Configuration $configuration);
 }

--- a/src/Core/Composer/RequireCache.php
+++ b/src/Core/Composer/RequireCache.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Ibuildings\QaTools\Core\Composer;
+
+use Ibuildings\QaTools\Core\Exception\RuntimeException;
+
+/**
+ * This is a set that stores Composer configurations that resulted from requiring
+ * a set of packages on an existing target configuration. It is used to optimize
+ * performance in CliComposerProject.
+ */
+final class RequireCache
+{
+    /**
+     * Composer configurations indexed by requiredPackages that were required.
+     *
+     * @var Configuration[]
+     */
+    private $configurations = [];
+
+    /**
+     * Stores the Composer newConfiguration that resulted from requiring the given set of
+     * requiredPackages.
+     *
+     * @param Configuration $targetConfiguration The configuration on which the require was performed.
+     * @param PackageSet    $requiredPackages
+     * @param Configuration $newConfiguration The configuration that resulted from the require.
+     * @return void
+     */
+    public function storeConfiguration(
+        Configuration $targetConfiguration,
+        PackageSet $requiredPackages,
+        Configuration $newConfiguration
+    ) {
+        $key = $this->getKey($targetConfiguration, $requiredPackages);
+
+        $this->configurations[$key] = $newConfiguration;
+    }
+
+    /**
+     * @param Configuration $targetConfiguration The configuration on which the require was performed.
+     * @param PackageSet    $requiredPackages
+     * @return Configuration The configuration that would result from the require.
+     * @throws RuntimeException When no configuration has been stored that describes the result of the requirement
+     *     wishes.
+     */
+    public function getConfiguration(Configuration $targetConfiguration, PackageSet $requiredPackages)
+    {
+        $key = $this->getKey($targetConfiguration, $requiredPackages);
+
+        if (!array_key_exists($key, $this->configurations)) {
+            throw new RuntimeException(
+                sprintf(
+                    'No configuration is cached for the given requirement wishes "%s"',
+                    join('", "', $requiredPackages->getDescriptors())
+                )
+            );
+        }
+
+        return $this->configurations[$key];
+    }
+
+    /**
+     * @param Configuration $targetConfiguration The configuration on which the require was performed.
+     * @param PackageSet    $requiredPackages
+     * @return boolean Whether a configuration is stored that describes the result of the requirement wishes.
+     * @throws RuntimeException When no configuration has been cached for the given requirements.
+     */
+    public function containsConfiguration(Configuration $targetConfiguration, PackageSet $requiredPackages)
+    {
+        $key = $this->getKey($targetConfiguration, $requiredPackages);
+
+        return array_key_exists($key, $this->configurations);
+    }
+
+    /**
+     * @param Configuration $targetConfiguration
+     * @param PackageSet    $requiredPackages
+     * @return string
+     */
+    private function getKey(Configuration $targetConfiguration, PackageSet $requiredPackages)
+    {
+        $packageDescriptors = join(',', $requiredPackages->getDescriptors());
+        $composerJson = $targetConfiguration->getComposerJson();
+        $composerLockJson = $targetConfiguration->hasLockedDependencies()
+            ? $targetConfiguration->getComposerLockJson()
+            : '';
+
+        return sha1(join(':', array_filter([$packageDescriptors, $composerJson, $composerLockJson])));
+    }
+}

--- a/src/Core/Composer/RequireCache.php
+++ b/src/Core/Composer/RequireCache.php
@@ -86,6 +86,6 @@ final class RequireCache
             ? $targetConfiguration->getComposerLockJson()
             : '';
 
-        return sha1(join(':', array_filter([$packageDescriptors, $composerJson, $composerLockJson])));
+        return sha1(join(':', [$packageDescriptors, $composerJson, $composerLockJson]));
     }
 }

--- a/src/Core/Task/Executor/InstallComposerDevDependencyTaskExecutor.php
+++ b/src/Core/Task/Executor/InstallComposerDevDependencyTaskExecutor.php
@@ -2,6 +2,7 @@
 
 namespace Ibuildings\QaTools\Core\Task\Executor;
 
+use Ibuildings\QaTools\Core\Composer\Configuration;
 use Ibuildings\QaTools\Core\Composer\Package;
 use Ibuildings\QaTools\Core\Composer\PackageSet;
 use Ibuildings\QaTools\Core\Composer\Project as ComposerProject;
@@ -15,12 +16,18 @@ use Ibuildings\QaTools\Core\Task\InstallComposerDevDependencyTask;
 use Ibuildings\QaTools\Core\Task\Task;
 use Ibuildings\QaTools\Core\Task\TaskList;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) -- Due to wide-spread value object usage a higher coupling is
+ *     acceptable
+ */
 final class InstallComposerDevDependencyTaskExecutor implements Executor
 {
     /** @var ComposerProjectFactory */
     private $composerProjectFactory;
     /** @var ComposerProject|null */
     private $composerProject;
+    /** @var Configuration|null */
+    private $configurationBackup;
 
     public function __construct(ComposerProjectFactory $composerProjectFactory)
     {
@@ -94,7 +101,7 @@ final class InstallComposerDevDependencyTaskExecutor implements Executor
 
         $packages = $this->getPackagesToAddAsDevDependency($tasks);
 
-        $this->composerProject->backUpConfiguration();
+        $this->configurationBackup = $this->composerProject->readConfiguration();
         $this->composerProject->requireDevDependencies($packages);
     }
 
@@ -105,7 +112,8 @@ final class InstallComposerDevDependencyTaskExecutor implements Executor
     public function rollBack(TaskList $tasks, Project $project, Interviewer $interviewer)
     {
         $interviewer->notice(" * Restoring Composer configuration...");
-        $this->composerProject->restoreConfiguration();
+
+        $this->composerProject->restoreConfiguration($this->configurationBackup);
     }
 
     /**

--- a/tests/integration/Core/Composer/CliComposerProjectTest.php
+++ b/tests/integration/Core/Composer/CliComposerProjectTest.php
@@ -114,9 +114,11 @@ class CliComposerProjectTest extends MockeryTestCase
 
             $this->fail(sprintf('No exception of type "%s" was thrown', RuntimeException::class));
         } catch (RuntimeException $e) {
-            $this->assertContains('Failed to dry-run Composer packages installation', $e->getMessage());
+            $this->assertContains('Failed to require development dependencies', $e->getMessage());
             $this->assertContains('Your requirements could not be resolved to an installable set of packages.', $e->getCause());
         }
+
+        Composer::assertPackageIsNotRequiredAsDevDependency('phpmd/phpmd');
     }
 
     /** @test */

--- a/tests/integration/Core/Composer/CliComposerProjectTest.php
+++ b/tests/integration/Core/Composer/CliComposerProjectTest.php
@@ -3,6 +3,7 @@
 namespace Ibuildings\QaTools\IntegrationTest\Core\Composer;
 
 use Ibuildings\QaTools\Core\Composer\CliComposerProject;
+use Ibuildings\QaTools\Core\Composer\Configuration;
 use Ibuildings\QaTools\Core\Composer\Package;
 use Ibuildings\QaTools\Core\Composer\PackageSet;
 use Ibuildings\QaTools\Core\Composer\RuntimeException;
@@ -72,16 +73,44 @@ class CliComposerProjectTest extends MockeryTestCase
     }
 
     /** @test */
+    public function can_read_the_current_composer_configuration_with_locked_dependencies()
+    {
+        $composerJson = '{"name": "pkg/pkg"}';
+        $composerLockJson = '{"content-hash":"fae3"}';
+
+        file_put_contents('composer.json', $composerJson);
+        file_put_contents('composer.lock', $composerLockJson);
+
+        $expectedConfiguration = Configuration::withLockedDependencies($composerJson, $composerLockJson);
+        $actualConfiguration = $this->project->readConfiguration();
+
+        $this->assertTrue($actualConfiguration->equals($expectedConfiguration));
+    }
+
+    /** @test */
+    public function can_read_the_current_composer_configuration_without_locked_dependencies()
+    {
+        $composerJson = '{"name": "pkg/pkg"}';
+
+        file_put_contents('composer.json', $composerJson);
+
+        $expectedConfiguration = Configuration::withoutLockedDependencies($composerJson);
+        $actualConfiguration = $this->project->readConfiguration();
+
+        $this->assertTrue($actualConfiguration->equals($expectedConfiguration));
+    }
+
+    /** @test */
     public function can_restore_a_composer_configuration()
     {
         Composer::initialise();
 
-        $this->project->backUpConfiguration();
+        $backup = $this->project->readConfiguration();
 
         $this->project->requireDevDependencies(new PackageSet([Package::of('phpmd/phpmd', '^2.0')]));
         $this->assertFileExists('vendor/phpmd/phpmd/composer.json');
 
-        $this->project->restoreConfiguration();
+        $this->project->restoreConfiguration($backup);
 
         $this->assertFileNotExists('vendor/phpmd/phpmd/composer.json');
     }

--- a/tests/system/Composer.php
+++ b/tests/system/Composer.php
@@ -60,4 +60,23 @@ final class Composer
     {
         assertFileNotExists(sprintf('vendor/%s', $packageName));
     }
+
+    /**
+     * @param string $packageName
+     */
+    public static function assertPackageIsNotRequiredAsDevDependency($packageName)
+    {
+        assertFileExists('composer.json');
+
+        $composerConfiguration = json_decode(file_get_contents('composer.json'), true);
+
+        if (!array_key_exists('require-dev', $composerConfiguration)) {
+            return;
+        }
+        if (!array_key_exists($packageName, $composerConfiguration['require-dev'])) {
+            return;
+        }
+
+        fail(sprintf('Package "%s" is required as a development dependency', $packageName));
+    }
 }

--- a/tests/system/assert.php
+++ b/tests/system/assert.php
@@ -2417,3 +2417,18 @@ function throwException(\Exception $exception)
         func_get_args()
     );
 }
+
+/**
+ * Fails a test with the given message.
+ *
+ * @param string $message
+ *
+ * @throws PHPUnit_Framework_AssertionFailedError
+ */
+function fail($message = '')
+{
+    return call_user_func_array(
+        'PHPUnit_Framework_Assert::fail',
+        func_get_args()
+    );
+}

--- a/tests/unit/Core/Composer/RequireCacheTest.php
+++ b/tests/unit/Core/Composer/RequireCacheTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Ibuildings\QaTools\UnitTest\Core\Composer;
+
+use Ibuildings\QaTools\Core\Composer\Configuration;
+use Ibuildings\QaTools\Core\Composer\Package;
+use Ibuildings\QaTools\Core\Composer\PackageSet;
+use Ibuildings\QaTools\Core\Composer\RequireCache;
+use Ibuildings\QaTools\Core\Exception\RuntimeException;
+use PHPUnit\Framework\TestCase;
+
+class RequireCacheTest extends TestCase
+{
+    /** @test */
+    public function stores_successful_requires()
+    {
+
+        $targetConfiguration = Configuration::withoutLockedDependencies('"target"');
+        $requiredPackages = new PackageSet([Package::of('phpmd/phpmd', '^2')]);
+        $newConfiguration = Configuration::withoutLockedDependencies('"new"');
+
+        $cache = new RequireCache();
+
+        $cache->storeConfiguration($targetConfiguration, $requiredPackages, $newConfiguration);
+    }
+
+    /** @test */
+    public function stores_successful_requires_of_0_packages()
+    {
+
+        $targetConfiguration = Configuration::withoutLockedDependencies('"target"');
+        $requiredPackages = new PackageSet();
+        $newConfiguration = Configuration::withoutLockedDependencies('"new"');
+
+        $cache = new RequireCache();
+
+        $cache->storeConfiguration($targetConfiguration, $requiredPackages, $newConfiguration);
+    }
+
+    /** @test */
+    public function contains_successful_requires()
+    {
+        $targetConfiguration = Configuration::withoutLockedDependencies('"target"');
+        $requiredPackages = new PackageSet([Package::of('phpmd/phpmd', '^2'), Package::of('phpunit/phpunit', '5')]);
+        $newConfiguration = Configuration::withoutLockedDependencies('"new"');
+
+        $cache = new RequireCache();
+        $cache->storeConfiguration($targetConfiguration, $requiredPackages, $newConfiguration);
+
+        $this->assertTrue($cache->containsConfiguration($targetConfiguration, $requiredPackages));
+    }
+
+    /** @test */
+    public function can_return_successful_requires()
+    {
+        $targetConfiguration = Configuration::withoutLockedDependencies('"target"');
+        $requiredPackages = new PackageSet([Package::of('phpunit/phpunit', '5')]);
+        $newConfiguration = Configuration::withoutLockedDependencies('"new"');
+
+        $cache = new RequireCache();
+        $cache->storeConfiguration($targetConfiguration, $requiredPackages, $newConfiguration);
+
+        $returnedConfiguration = $cache->getConfiguration($targetConfiguration, $requiredPackages);
+
+        $this->assertTrue($returnedConfiguration->equals($newConfiguration));
+    }
+
+    /** @test */
+    public function throws_an_exception_when_getting_a_nonexistent_configuration()
+    {
+        $targetConfiguration = Configuration::withoutLockedDependencies('"target"');
+        $requiredPackages = new PackageSet(
+            [Package::of('phpmd/phpmd', '^2'), Package::of('ibuildingsnl/qa-tools', '3.0.0-beta1')]
+        );
+
+        $cache = new RequireCache();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(
+            'No configuration is cached for the given requirement wishes ' .
+            '"phpmd/phpmd:^2", "ibuildingsnl/qa-tools:3.0.0-beta1"'
+        );
+
+        $cache->getConfiguration($targetConfiguration, $requiredPackages);
+    }
+}

--- a/tests/unit/Core/Composer/RequireCacheTest.php
+++ b/tests/unit/Core/Composer/RequireCacheTest.php
@@ -14,7 +14,6 @@ class RequireCacheTest extends TestCase
     /** @test */
     public function stores_successful_requires()
     {
-
         $targetConfiguration = Configuration::withoutLockedDependencies('"target"');
         $requiredPackages = new PackageSet([Package::of('phpmd/phpmd', '^2')]);
         $newConfiguration = Configuration::withoutLockedDependencies('"new"');
@@ -27,7 +26,6 @@ class RequireCacheTest extends TestCase
     /** @test */
     public function stores_successful_requires_of_0_packages()
     {
-
         $targetConfiguration = Configuration::withoutLockedDependencies('"target"');
         $requiredPackages = new PackageSet();
         $newConfiguration = Configuration::withoutLockedDependencies('"new"');


### PR DESCRIPTION
Perform full Composer dev dependency conflict detection by actually requiring the dev dependencies. The configuration is then stored in memory, only to be restored during the execution phase. As the packages are cached, this shouldn't introduce such a performance hit.

Fixes #113